### PR TITLE
chore(wezterm): remove window padding

### DIFF
--- a/.config/wezterm/wezterm.lua
+++ b/.config/wezterm/wezterm.lua
@@ -98,10 +98,10 @@ config.window_background_gradient = {
 }
 
 config.window_padding = {
-  left = "1cell",
-  right = "1cell",
-  top = "0.5cell",
-  bottom = "0.5cell",
+  left = "0",
+  right = "0",
+  top = "0",
+  bottom = "0",
 }
 
 ------------------------------


### PR DESCRIPTION
## Summary
- Remove window padding configuration to maximize terminal space

## Changes
- Set all window padding values (left, right, top, bottom) to "0"

## Test plan
- [x] Verified WezTerm launches successfully with the updated configuration
- [x] Confirmed window padding is removed as expected

🤖 Generated with [Claude Code](https://claude.ai/code)