### PR TITLE
feat: add file/directory copy functionality to resolve Claude Code symlink issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,12 @@ Personal dotfiles management tool that automatically sets up development environ
 ### Features
 
 - Automatic symlink creation for dotfiles to home directory
+- **File/directory copying for Claude Code compatibility** - Copies specific files/directories instead of creating symlinks to resolve Claude Code's symlink issues
 - Cross-platform support (macOS, Windows, WSL)
 - Cursor editor settings synchronization
 - Selective file exclusion with `.dotfilesignore`
+- Dry-run mode to preview operations
+- Interactive confirmation for existing files
 
 ## Usage
 
@@ -24,12 +27,32 @@ Personal dotfiles management tool that automatically sets up development environ
 3. Run the setup script:
 
 ```bash
+# Normal execution
 go run setup.go
+
+# Dry-run mode (preview operations without making changes)
+go run setup.go --dry-run
 ```
 
-**Note**: The script will overwrite existing dotfiles in your home directory with symlinks.
+### Behavior
+
+- **Symlinks**: Most dotfiles will be symlinked to your home directory
+- **File copying**: Specific files/directories (like `.claude`) will be copied instead of symlinked to ensure Claude Code compatibility
+- **Existing files**:
+  - Symlinks are automatically replaced
+  - Regular files/directories prompt for confirmation before removal
+  - You can skip files by choosing "No" when prompted
 
 ## Configuration
+
+### Copy targets
+
+Files and directories defined in `COPY_TARGETS` (in `setup.go`) will be copied instead of symlinked. Currently configured for:
+
+- `.claude` directory and its contents
+- `.claude/commands` directory
+
+To modify copy targets, edit the `COPY_TARGETS` variable in `setup.go`.
 
 ### Excluding files
 

--- a/setup.go
+++ b/setup.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"log"
 	"os"
 	"path/filepath"
@@ -166,6 +167,10 @@ func linkCursorSettings() {
 }
 
 func main() {
+	var dryRun bool
+	flag.BoolVar(&dryRun, "dry-run", false, "Show what would be done without making any changes")
+	flag.Parse()
+
 	files, err := searchDotfiles()
 	if err != nil {
 		log.Fatal(err)
@@ -176,11 +181,20 @@ func main() {
 	for _, f := range files {
 		n := filepath.Base(f)
 		dst := home + "/" + n
-		err := createSymlink(f, dst)
-		if err != nil {
-			log.Fatal(err)
+		
+		if dryRun {
+			log.Printf("Would create symlink: %s -> %s", f, dst)
+		} else {
+			err := createSymlink(f, dst)
+			if err != nil {
+				log.Fatal(err)
+			}
 		}
 	}
 
-	linkCursorSettings()
+	if dryRun {
+		log.Printf("Would link Cursor settings")
+	} else {
+		linkCursorSettings()
+	}
 }

--- a/setup.go
+++ b/setup.go
@@ -8,6 +8,12 @@ import (
 	"strings"
 )
 
+// COPY_TARGETS specifies the files and directories to be copied instead of symlinked
+var COPY_TARGETS = []string{
+	".claude",
+	".claude/commands",
+}
+
 func createSymlink(src, dst string) error {
 	if _, err := os.Lstat(dst); err == nil {
 		os.Remove(dst)

--- a/setup.go
+++ b/setup.go
@@ -326,12 +326,37 @@ func main() {
 		n := filepath.Base(f)
 		dst := home + "/" + n
 		
-		if dryRun {
-			log.Printf("Would create symlink: %s -> %s", f, dst)
-		} else {
-			err := createSymlink(f, dst)
+		// Check if this path should be copied instead of symlinked
+		if shouldCopyPath(f) {
+			// Handle existing path
+			err := handleExistingPath(dst, dryRun)
 			if err != nil {
+				if strings.Contains(err.Error(), "skipping") {
+					log.Printf("Skipping %s", dst)
+					continue
+				}
 				log.Fatal(err)
+			}
+			
+			// Copy the file or directory
+			if dryRun {
+				log.Printf("Would copy: %s -> %s", f, dst)
+			} else {
+				log.Printf("Copying: %s -> %s", f, dst)
+				err := copyFileOrDir(f, dst)
+				if err != nil {
+					log.Fatal(err)
+				}
+			}
+		} else {
+			// Create symlink as before
+			if dryRun {
+				log.Printf("Would create symlink: %s -> %s", f, dst)
+			} else {
+				err := createSymlink(f, dst)
+				if err != nil {
+					log.Fatal(err)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

This pull request implements file and directory copy functionality to resolve Claude Code's symlink compatibility issues. Claude Code cannot properly read symlinked files, particularly the ~/.claude directory, which prevents proper configuration loading.

The solution copies specific files/directories defined in COPY_TARGETS while maintaining symlink behavior for other dotfiles. It includes dry-run mode for operation preview and interactive confirmation for existing file handling.